### PR TITLE
apply fix to support existing functions outside this service to be used, d…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,13 @@ const { addAliases, addAPIGatewayConfig } = require('./cloudFormationBuilder');
 const PLUGIN_CONFIG_KEY = 'simpleAlias';
 const PLUGIN_NAME = 'serverless-simple-alias';
 
+// turn off by default for lambdas that do not use alias
+// so that framework can provide this feature only for required lambdas
 const DEFAULT_CONFIG = {
-  activeAliasName: 'ACTIVE',
-  useActiveAliasInGateway: true,
-  makeLambdasActive: true,
+  activeAliasName: 'INACTIVE',
+  useActiveAliasInGateway: false,
+  makeLambdasActive: false,
+  aliases: []
 };
 
 class ResolveStageVars {


### PR DESCRIPTION
Request a fix, plus an update for the default behavior.

1. For functions in serverless configuration, that have ARN uses, example below, the script fails as always expects function to be in format: { 'Fn::GetAtt': [ 'SomeFunctionName', 'Arn' ] }, when reading lambda permissions resources over the function, that is now referred by ARN. Handle that scenario.


```
      - http:
          path: /my_path
          method: get
          authorizer:
            arn: ${self:provider.environment.EXISTING_AUTHORIZER_ARN}
```

 https://docs.aws.amazon.com/lambda/latest/dg/urls-configuration.html.
```
Valid name formats include the following:

Function name – my-function
Function ARN – arn:aws:lambda:us-west-2:123456789012:function:my-function
```


2. Default behavior is to keep plugin active. But it is frequent case when plugins are controlled via a master framework file. If plugin is enabled by default, it would start activating 'alias' even for functions that do not require alias functionality ( for example this was needed to enable snapstart for Java functions, by activating alias and making APIGW point to alias).

https://github.com/serverless/serverless/discussions/11570

This is proposed to be de-activated by default.